### PR TITLE
Fix unsafe access to request.json fields

### DIFF
--- a/routes/main.py
+++ b/routes/main.py
@@ -55,10 +55,14 @@ def load():
     """Endpoint to load user data."""
     data = request.json
 
-    access_token = str(data.get("access_token"))
-    username = str(data.get("username"))
-    timezone = str(data.get("timezone"))
-    year = int(data.get("year"))
+    if data is None:
+        return jsonify({"redirect_url": url_for("auth.index")})
+
+    access_token = str(data.get("access_token", ""))
+    username = str(data.get("username", ""))
+    timezone = str(data.get("timezone", ""))
+    year_val = data.get("year")
+    year = int(year_val) if year_val is not None else 0
 
     # Validate request data
     if not DataService.validate_request_data(access_token, username, timezone, year):


### PR DESCRIPTION
The `load` route was accessing `request.json` without checking if it was None. This could happen if the Content-Type is not application/json or the body is empty, leading to a TypeError when calling `.get()` on a None object.

This PR adds:
1. A check for `data is None` at the beginning of the `load` function.
2. Default values in `.get()` calls to prevent issues if fields are missing.
3. A safer way to parse the `year` field.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.